### PR TITLE
Multi-storage-file tracking WIP

### DIFF
--- a/src/backend/datasets/models.py
+++ b/src/backend/datasets/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.contrib.auth.models import User
-from rawstatus.models import RawFile, ServerShare
+from rawstatus.models import RawFile, ServerShare, DataSecurityClass
 from jobs.models import Job
 
 
@@ -97,20 +97,13 @@ class DatatypeComponent(models.Model):
         return f'{self.datatype.name} has component {DatasetUIComponent(self.component).label}'
 
 
-class DatasetSecurityClass(models.IntegerChoices):
-    # Go from lowest to highest classification
-    NOSECURITY = 1, 'Not classified'
-    # FIXME when ready, also have personal data dsets
-    # PERSONAL = 2, 'Personal data'
-
-
 class Dataset(models.Model):
     date = models.DateTimeField('date created')
     runname = models.OneToOneField(RunName, on_delete=models.CASCADE)
     #experiment = models.ForeignKey(Experiment, on_delete=models.CASCADE)
     #runname = models.TextField()
     datatype = models.ForeignKey(Datatype, on_delete=models.CASCADE)
-    securityclass = models.IntegerField(choices=DatasetSecurityClass.choices)
+    securityclass = models.IntegerField(choices=DataSecurityClass.choices)
     # NB! storage_loc/share should only ever be updated in jobs' post-run (after moves)
     # because it is source of truth for where to/from move files
     storage_loc = models.TextField(max_length=200, unique=True)

--- a/src/backend/rawstatus/models.py
+++ b/src/backend/rawstatus/models.py
@@ -51,6 +51,13 @@ class MSInstrument(models.Model):
         return 'MS - {}/{}'.format(self.producer.name, self.filetype.name)
 
 
+class DataSecurityClass(models.IntegerChoices):
+    # Go from lowest to highest classification
+    NOSECURITY = 1, 'Not classified'
+    # FIXME when ready, also have personal data dsets
+    # PERSONAL = 2, 'Personal data'
+
+
 class FileServer(models.Model):
     name = models.TextField(unique=True)
     uri = models.TextField() # for users
@@ -64,9 +71,11 @@ class ServerShare(models.Model):
     name = models.TextField(unique=True)  # storage, tmp,
     server = models.ForeignKey(FileServer, on_delete=models.CASCADE)
     share = models.TextField()  # /home/disk1
+    max_security = models.IntegerField(choices=DataSecurityClass.choices)
 
     def __str__(self):
         return self.name
+
 
 class RawFile(models.Model):
     """Data (raw) files as reported by instrument"""


### PR DESCRIPTION
This PR will contain the following:

A storedfile will have related model with servershare/path, which it can have multiple of, as not to have to duplicate rows there (before this PR a storedfile has servershare/path, and is also not expected to be duplicated except for mzMLs etc). Yes, that means a lot of refactoring, we need to know what to pass to different jobs, what to return to the user UI, etc etc. A problem arising from this is that job args will change, invalidating older jobs - so we'll have to do some cleaning up there or migrate existing jobs.

Servershare will have max data security level, so we can decide whether we are allowed to store personal data there or not.

Transfer jobs to move files between servers.

