### PR TITLE
Fix convert job doesnt wait for rsync hold accept

### DIFF
--- a/src/backend/home/urls.py
+++ b/src/backend/home/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
     path('refresh/dataset/<int:dset_id>', views.refresh_dataset),
     path('refresh/file/<int:fn_id>', views.refresh_file),
     path('refresh/analysis/<int:anid>', views.refresh_analysis, name="analysisrefresh"),
-    path('createmzml/', views.create_mzmls),
-    path('refinemzml/', views.refine_mzmls),
+    path('mzml/create/', views.create_mzmls),
+    path('mzml/refine/', views.refine_mzmls),
+    path('mzml/delete/', views.delete_mzmls),
 ]

--- a/src/backend/rawstatus/tests.py
+++ b/src/backend/rawstatus/tests.py
@@ -764,7 +764,7 @@ class TestUploadScript(BaseIntegrationTest):
         resp = self.post_json({'dataset_id': self.oldds.pk, 'accepted_files': [self.newsf.sfile_id],
             'rejected_files': []})
         self.assertEqual(resp.status_code, 200)
-        self.url = '/createmzml/'
+        self.url = '/mzml/create/'
         am.NfConfigFile.objects.create(serverprofile=self.anaprofile2, nfpipe=self.nfwv, nfconfig=self.nfc_lf)
         resp = self.cl.post(self.url, content_type='application/json', data={'pwiz_id': self.pwiz.pk,
             'dsid': self.oldds.pk})

--- a/src/backend/rawstatus/views.py
+++ b/src/backend/rawstatus/views.py
@@ -1393,7 +1393,7 @@ def delete_file(request):
     elif hasattr(sfile.rawfile, 'datasetrawfile'):
         dset = dsmodels.Dataset.objects.filter(datasetrawfile__rawfile=sfile.rawfile).values('pk',
                 'runname__experiment__project__ptype_id', 'deleted').get()
-        if not data.get('force'):
+        if sfloc_q.filter(sfile__mzmlfile__isnull=True) and not data.get('force'):
             return JsonResponse({'error': 'File is in a dataset, force delete, archive entire set, '
                 'or remove it from dataset first'}, status=402)
         elif dsviews.check_ownership(request.user, dset['runname__experiment__project__ptype_id'],


### PR DESCRIPTION
Now job runner will wait for the dataset-pre-assigned files with an rsync job, as those jobs now also get a filejob entry. Also added possibility to delete mzMLs for a dataset.

Fixes #149